### PR TITLE
Added new rule for Low Command.

### DIFF
--- a/lowcommandGuide.md
+++ b/lowcommandGuide.md
@@ -59,4 +59,4 @@ By Executive Order #1 issued by Central Command in Space Law, it is imperative t
 
   **5. Sector Administrative Responsibilities:** Station command can on discretion to cover station and security crew expenses upon request, if a ship is being reimbursed, it shall be considered station property, selling a reimbursed ship shall be considered embezzlement. Unless the received funds from the reimbursed ship is used to cover station expenses.
 
-  **6. Whenever you wish to end your shift, do add at least only 1 more station command job you play as in the station records computer:** This is to allow other low command members to step in and become station command whenever you decide to end your shift. Failure to do so may lead to a lack of sector command, which can lead to severe consequences.
+  **6. Whenever you wish to end your shift, you need to add at least only 1 more station command job you play as in the station records computer:** This is to allow other low command members to step in and become station command whenever you decide to end your shift. Failure to do so may lead to a lack of sector command, which can lead to severe consequences.

--- a/lowcommandGuide.md
+++ b/lowcommandGuide.md
@@ -58,3 +58,5 @@ By Executive Order #1 issued by Central Command in Space Law, it is imperative t
   **4. Enforce and delegate conscientiously** Rules 1, 2, 5, and 6 can be enforced by Low Command. Rules 3, 4, 8, and up are to be handled by Central Command and any inquiries related to them should be delegated to CC. 
 
   **5. Sector Administrative Responsibilities:** Station command can on discretion to cover station and security crew expenses upon request, if a ship is being reimbursed, it shall be considered station property, selling a reimbursed ship shall be considered embezzlement. Unless the received funds from the reimbursed ship is used to cover station expenses.
+
+  **6. Whenever you wish to end your shift, do add at least only 1 more station command job you play as in the station records computer:** This is to allow other low command members to step in and become station command whenever you decide to end your shift. Failure to do so may lead to a lack of sector command, which can lead to severe consequences.


### PR DESCRIPTION
There is a critical thing Low Command has to do that no members of Low Command have knowledge about, which is that you need to add at least 1 station command role to the computer, so other Low Command members can step in when one member currently playing as station command ends their shift. This should allow a bit more knowledge for Low Command members to be more responsible.